### PR TITLE
feat(documentation-swagger): add documentation to api

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'django_extensions',
     'rest_framework',
+    'rest_framework_swagger',
 
     'authors.apps.authentication',
     'authors.apps.core',

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -15,10 +15,13 @@ Including another URLconf
 """
 from django.urls import include, path
 from django.contrib import admin
+from rest_framework_swagger.views import get_swagger_view
+
+schema_view = get_swagger_view(title='Authors Haven API')
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-
     path('api/', include('authors.apps.authentication.urls')),
+    path('swagger-docs/', schema_view),
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ djangorestframework==3.8.2
 PyJWT==1.4.2
 pytz==2018.5
 six==1.10.0
+django-rest-swagger==2.2.0


### PR DESCRIPTION
#### What does this PR do?
Creates documentation for the API

#### Description of Task to be completed?
Currently, there is no documentation for the API.

This task creates documentation for the API endpoints that are available and will also reflect all endpoints that will be created after here.

#### How should this be manually tested?
Run ```pip install -r requirements.txt``` in the terminal to install swagger
Run the server and navigate to https://localhost:8000/swagger-docs/
The documentation should appear

#### What are the relevant pivotal tracker stories?
[#160609548](https://www.pivotaltracker.com/story/show/160609548)


#### Any background context you want to add?
N/A

#### Screenshots

![image](https://user-images.githubusercontent.com/9901011/46102243-8eef2700-c1d6-11e8-8c5a-df9ba9f0fff2.png)
