### PR TITLE
#160609550 Return descriptive validation errors at registration

### DIFF
--- a/authors/apps/authentication/renderers.py
+++ b/authors/apps/authentication/renderers.py
@@ -21,5 +21,6 @@ class UserJSONRenderer(JSONRenderer):
 
         # Finally, we can render our data under the "user" namespace.
         return json.dumps({
+            'message':'Successful',
             'user': data
         })

--- a/authors/apps/authentication/validators.py
+++ b/authors/apps/authentication/validators.py
@@ -1,0 +1,30 @@
+import re
+
+from pyisemail import is_email
+from rest_framework import serializers
+
+
+class ValidateUserDetails:
+    """Class adds validator methods for user details"""
+    
+    def is_password_valid(self, password):
+        if len(password) < 8:
+            raise serializers.ValidationError(
+                {'password': 'The password should be atleast 8 characters'}
+            )
+        if (re.match('(?=.*[0-9])(?=.*[a-zA-Z])', password)) is None:
+            raise serializers.ValidationError(
+                {'password': 'The password should have atleast one number and a letter'}
+            )
+
+    def is_username_valid(self, username):
+        if len(username) < 4:
+            raise serializers.ValidationError(
+                {'username': 'The username should be atleast 4 characters'}
+            )
+
+    def is_email_valid(self, email):
+        if not is_email(email):
+            raise serializers.ValidationError(
+                {'email': 'Enter a valid email address.'}
+            )

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import jwt
 import sendgrid
 from decouple import config
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -27,11 +27,11 @@ class RegistrationAPIView(APIView):
 
     def post(self, request):
         user = request.data.get('user', {})
-
         # The create serializer, validate serializer, save serializer pattern
         # below is common and you will see it a lot throughout this course and
         # your own work later on. Get familiar with it.
         serializer = self.serializer_class(data=user)
+
         serializer.is_valid(raise_exception=True)
         serializer.save()
 


### PR DESCRIPTION
### What does this PR do?

Add descriptive descriptive validation error messages on user registration

#### Description of Task to be completed?

Currently, when a user is signing up, they get default error messages which are generated by the of DRF which are not descriptive enough for the Authors Haven app

This task ensures that users get specific error responses on validating the user inputs. The PR covers both invalid and valid valid user parameters 

#### How should this be manually tested?

`POST /api/users`

Registration details:

```source-json
{
  "user":{
    "username": "Jacob",
    "email": "jake@jake.jake",
    "password": "jakejake"
  }
}
```

Registration with invalid email:

```source-json
{
  "user":{
    "username": "Jacob",
    "email": "jakejake.jake",
    "password": "jakejake"
  }
}
```

#### Any background context you want to provide?

N/A

#### Screenshots

<img width="821" alt="screen shot 2018-09-28 at 11 45 36" src="https://user-images.githubusercontent.com/31615608/46198215-9583b880-c314-11e8-8904-ab94454dd7a8.png">


#### What are the relevant pivotal tracker stories?

[#160609550](https://www.pivotaltracker.com/story/show/160609550)