### PR TITLE
#160609551 Receive verification email on registration

### DIFF
--- a/authors/apps/authentication/tests.py
+++ b/authors/apps/authentication/tests.py
@@ -1,9 +1,10 @@
 # tests for authentication application
-from django.test import TestCase
-from rest_framework.test import APIClient
-from rest_framework import status
-
 from authors.apps.authentication.models import User, UserManager
+from authors.apps.authentication.views import (generate_ver_token,
+                                               send_verification_link)
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
 
 
 class ModelTestCase(TestCase):
@@ -179,3 +180,7 @@ class ViewTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert "auth_token" in response.data
 
+    def test_send_email_on_registration(self):
+        token = generate_ver_token(self.user_data['user']['email'])
+        res = send_verification_link(self.user_data['user']['email'], token)
+        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pylint==2.1.1
 python-decouple==3.1
 pytz==2018.5
 requests==2.19.1
+sendgrid==5.6.0
 simplejson==3.16.0
 six==1.10.0
 uritemplate==3.0.0


### PR DESCRIPTION
### What does this PR do?

Add feature to receive a verification link via email upon successful signup 

#### Description of Task to be completed?

Currently, when a user creates an account, there is no link sent to their email to verify the account

This task ensures that upon successful signup, an email with verification link is sent to the user’s email.  


#### How should this be manually tested?
- First, create a SendGrid free account [here](https://signup.sendgrid.com/?id=71713987-9f01-4dea-b3d4-8d0bcd9d53ed) and select option of Web API to create your own ``` SENDGRID_API_KEY ```
- Add ``` SENDGRID_API_KEY=the_generated_key ``` in your .env file and save
- Register a user on the endpoint ```POST /api/users``` entering the user data in format below
{
  "user":{
    "username": “Username”,
    "email": “your@email.com”,
    "password": “password1”
  }
} 

- Open your email used for registration, you should find an email from ```targaryen@authorshaven.com```  with the verification link. If it is not seen in the inbox, check in the spam mail.

#### What are the relevant pivotal tracker stories?

- [#160609551](https://www.pivotaltracker.com/story/show/160609551)

#### Screenshots (if appropriate)
<img width="1187" alt="screen shot 2018-10-04 at 17 48 27" src="https://user-images.githubusercontent.com/31615608/46482230-e2c4c600-c7fd-11e8-8e04-112bc2048273.png">


