### PR TITLE
#161013446 Fix security vulnerability in Django 2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coreschema==0.0.4
 coverage==4.5.1
 coveralls==1.5.0
 dj-database-url==0.5.0
-Django==2.1.1
+Django==2.1.2
 django-cors-middleware==1.3.1
 django-extensions==2.1.2
 django-filter==2.0.0


### PR DESCRIPTION
### What does this PR do?

Update Django from release 2.1.1 to release 2.1.2 to to fix the dependency vulnerability issue 

#### Description of Task to be completed?

Currently, there is a notification on the GitHub showing that a dependency defined in ```requirements.txt``` has known security vulnerabilities and should be updated. The dependency
Is Django 2.1.1 where “view only” admin users can view hashed passwords


This PR updates Django version in  ```requirements.txt``` from Django 2.1.1 to Django 2.1.2 which  fixes this security issue. 


#### How should this be manually tested?

- With administrator rights, open the root directory of the project on GitHub. A notification " A dependency defined in requirements.txt has known security vulnerabilities and should be updated. " is displayed
- On local machine, re-create your virtual environment and run ``` pip install -r requirements.txt ```
- Run ``` python -Wa manage.py test ``` to be sure the tests are running successfully

#### What are the relevant pivotal tracker stories?

- [#161013446](https://www.pivotaltracker.com/story/show/161013446)