### PR TITLE
#161107802 fix missing slash on url

### DIFF
--- a/authors/apps/profiles/tests.py
+++ b/authors/apps/profiles/tests.py
@@ -37,7 +37,7 @@ class ViewTestCase(TestCase):
     def test_profile_retreival(self):
         """Tests that a profile is created and retreived"""
         response = self.client.get(
-            '/api/profiles/{}'.format(self.username))
+            '/api/profiles/{}/'.format(self.username))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_profile_update(self):

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -3,6 +3,6 @@ from django.urls import path
 from .views import ProfileRetrieveUpdateAPIView
 
 urlpatterns = [
-    path('profiles/<username>', ProfileRetrieveUpdateAPIView.as_view()),
+    path('profiles/<username>/', ProfileRetrieveUpdateAPIView.as_view()),
     path('profiles/update/', ProfileRetrieveUpdateAPIView.as_view()),
 ]


### PR DESCRIPTION
### What does this PR do?

Adds a missing slash at the end of the profiles retrieval URL

#### Description of Task to be completed?

Currently, the URL of profile retrieval does not have a slash at the end as is the standard being followed for this project
This PR adds a front slash to the end of the profile retrieval URL

#### How should this be manually tested?

Enter the URL for retrieving a profile in postman with a forward slash at the end
You should be able to retrieve a profile of the user specified

#### What are the relevant pivotal tracker stories?

- [#161107802](https://www.pivotaltracker.com/story/show/161107802)