### PR TITLE
#160609562 list all users

### DIFF
--- a/authors/apps/profiles/tests.py
+++ b/authors/apps/profiles/tests.py
@@ -13,6 +13,7 @@ class ViewTestCase(TestCase):
     def setUp(self):
         """Define the test client and test variables"""
         self.client = APIClient()
+        self.unauthorized_client = APIClient()
 
         self.username = "johndoe"
         self.email = "johndoe@gmail.com"
@@ -28,7 +29,8 @@ class ViewTestCase(TestCase):
                                          "avatar": self.avatar}}
 
         self.response = self.client.post(
-            '/api/users/', self.user_data, format="json")
+            '/api/users/', self.user_data, format="json"
+        )
 
         self.client.credentials(
             HTTP_AUTHORIZATION='Token ' + self.response.data['auth_token']
@@ -37,20 +39,46 @@ class ViewTestCase(TestCase):
     def test_profile_retreival(self):
         """Tests that a profile is created and retreived"""
         response = self.client.get(
-            '/api/profiles/{}/'.format(self.username))
+            '/api/profiles/{}/'.format(self.username)
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_profile_retreival_without_authentication(self):
+        """Tests that a profile cant be retrieved without authentication"""
+        response = self.unauthorized_client.get(
+            '/api/profiles/{}/'.format(self.username)
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_profile_update(self):
         """Tests that a profile can be updated by a user"""
         response = self.client.put(
-            '/api/profiles/update/', data=self.profile_data, format='json')
+            '/api/profiles/update/', data=self.profile_data, format='json'
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(
             self.profile_data['profile']['username'], response.data['username']
-            )
+        )
         self.assertIn(
             self.profile_data['profile']['bio'], response.data['bio']
-            )
+        )
         self.assertIn(
             self.profile_data['profile']['avatar'], response.data['avatar']
         )
+
+    def test_profile_update_without_authentication(self):
+        """Tests that a profile cant be updated without authentication"""
+        response = self.unauthorized_client.put(
+            '/api/profiles/update/', data=self.profile_data, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_retrieval_of_all_user_profiles(self):
+        """Tests that all user profiles can be retrieved"""
+        response = self.client.get('/api/profile/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unauthenticated_retrieval_of_all_user_profiles(self):
+        """Tests that all profiles cant be retrieves without authentication"""
+        response = self.unauthorized_client.get('/api/profile/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
 
-from .views import ProfileRetrieveUpdateAPIView
+from .views import (
+    ProfileRetrieveUpdateAPIView,
+    ProfileList
+)
 
 urlpatterns = [
     path('profiles/<username>/', ProfileRetrieveUpdateAPIView.as_view()),
     path('profiles/update/', ProfileRetrieveUpdateAPIView.as_view()),
+    path('profile/', ProfileList.as_view()),
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -1,6 +1,9 @@
 from django.shortcuts import render
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import (
+    RetrieveUpdateAPIView,
+    RetrieveAPIView
+)
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
@@ -46,3 +49,15 @@ class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
         serializer.update(request.user, serializer_data)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ProfileList(RetrieveAPIView):
+    renderer_classes = (ProfileJSONRenderer,)
+    serializer_class = ProfileSerializer
+    permission_classes = (IsAuthenticated,)
+    authentication_classes = (JWTAuthentication,)
+
+    def retrieve(self, request, *args, **kwargs):
+        queryset = Profile.objects.all()
+        serializer = self.serializer_class(queryset, many=True)
+        return Response({"users": serializer.data}, status=status.HTTP_200_OK)


### PR DESCRIPTION
### What does this PR do?

Allows a logged in user to retrieve a list of all users and their profiles

### Description of tasks to be completed?

Currently, a user cannot view a list of all other users and their profiles.
This PR adds functionality to allow logged in users to view a list of all users on Authors Heaven and also view their profiles.

### How should this be manually tested?

Run the server `python manage.py runserver`
Open postman and login to an existing user account. Copy the token from the login result.
Enter the URL to get all users GET `http://127.0.0.1:8000/api/profile/`. Add an authentication header with a token got from logging in.
You should receive a list of all users and their profiles

### What are the relevant pivotal tracker stories?

[#160609562](https://www.pivotaltracker.com/story/show/160609562)

### Any background context you want to add?

Ensure to have a `SENDGRID_API_KEY` in your environment variables as shown in [PR #16](https://github.com/andela/ah-backend-targaryen/pull/16)

### Screenshots

Results got from the retrieval of the user list.
<img width="826" alt="screen shot 2018-10-10 at 20 54 56" src="https://user-images.githubusercontent.com/38077368/46795212-409f6380-cd52-11e8-9d47-5f3f9c23deb8.png">
