### PR TITLE
#160609560, #160609558 like and favourite articles

### DIFF
--- a/authors/apps/articles/management/commands/populate_impression.py
+++ b/authors/apps/articles/management/commands/populate_impression.py
@@ -1,0 +1,30 @@
+from django.core.management.base import (
+    BaseCommand,
+    CommandError
+)
+
+from authors.apps.articles.models import Impression
+
+
+class Command(BaseCommand):
+    help = "Populate the impressions table."
+
+    def handle(self, *args, **options):
+        impressions = [
+            {'Like': 'Person finds the article appeasing'},
+            {'Dislike': 'Person does not find the article to their liking'},
+            {'Favourite': "Person has found that they resonate with an article's words"}
+        ]
+        try:
+            Impression.objects.get(name='Like')
+            message = 'No need to populate Impression table.'
+        except Impression.DoesNotExist:
+            for impression in impressions:
+                for key, value in impression.items():
+                    Impression.objects.create(
+                        name=key,
+                        description=value
+                    ).save()
+            message = 'Impression Table has been populated'
+
+        self.stdout.write(self.style.SUCCESS(message))

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -20,6 +20,9 @@ class Article(models.Model):
     tags = models.ManyToManyField(
         'articles.Tag', related_name='articles'
     )
+    likes = models.PositiveIntegerField(default=0)
+    dislikes = models.PositiveIntegerField(default=0)
+    favourite_count = models.PositiveIntegerField(default=0)
 
     @staticmethod
     def get_article(slug):
@@ -81,11 +84,36 @@ class Article(models.Model):
 
 class Tag(models.Model):
     """Model for tags """
-    
+
     tag = models.CharField(max_length=255)
     createdAt = models.DateTimeField(auto_now_add=True, null=True)
     updatedAt = models.DateTimeField(auto_now=True, null=True)
-    
+
     def __str__(self):
         return self.tag
-        
+   
+
+
+class Impression(models.Model):
+    name = models.CharField(max_length=50)
+    description = models.CharField(max_length=100)
+    image = models.URLField(blank=True)
+
+
+class Reaction(models.Model):
+    '''
+    This model stores the likes,
+    dislikes and favourites that users add to articles
+    '''
+    article = models.ForeignKey(
+        Article, models.SET_NULL, blank=False, null=True,
+    )
+    user = models.ForeignKey(
+        User, models.SET_NULL, blank=False, null=True,
+    )
+    reaction = models.ForeignKey(
+        Impression, models.SET_NULL, blank=False, null=True,
+    )
+
+    def __int__(self):
+        return self.article_id

--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -12,3 +12,15 @@ class ArticleJSONRenderer(JSONRenderer):
         :return JSON object with key article"""
 
         return json.dumps({'article': data})
+
+
+class ReactionJSONRenderer(JSONRenderer):
+    """Class to render reactions"""
+    charset = 'utf-8'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        """Method to convert data to a specific format
+        :params data
+        :return JSON object with key reaction"""
+
+        return json.dumps({'reaction': data})

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,9 +1,6 @@
-from rest_framework import serializers
+from rest_framework import exceptions, serializers
 
-from .models import (
-    Article,
-    Tag
-)
+from .models import Article, Impression, Reaction, Tag
 from .relations import TagRelatedField
 
 
@@ -15,8 +12,9 @@ class ArticleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Article
         fields = [
-            'author', 'title', 'description', 'body',
-            'createdAt', 'updatedAt', 'slug', 'tagList'
+            'author', 'title', 'description',
+            'body', 'createdAt', 'updatedAt',
+            'slug', 'favourite_count', 'likes', 'dislikes', 'tagList'
         ]
 
     def create(self, validated_data):
@@ -36,3 +34,90 @@ class TagSerializer(serializers.ModelSerializer):
 
     def to_representation(self, value):
         return value.tag
+        return Article.objects.create(author=author, **validated_data)
+
+
+class ReactionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Reaction
+        fields = ['article', 'user', 'reaction']
+
+    @staticmethod
+    def reaction_value(reaction, article_slug, article, reaction_integer):
+        react_id = 0
+
+        if reaction == Impression.objects.get(name='Like').id:
+            react_id = 1
+            updated_likes = article.likes + reaction_integer
+            Article.objects.filter(slug=article_slug).update(
+                likes=updated_likes
+            )
+        elif reaction == Impression.objects.get(name='Dislike').id:
+            react_id = 2
+            updated_dislikes = article.dislikes + reaction_integer
+            Article.objects.filter(slug=article_slug).update(
+                dislikes=updated_dislikes
+            )
+        elif reaction == Impression.objects.get(name='Favourite').id:
+            react_id = 3
+            updated_favourites = article.favourite_count + reaction_integer
+            Article.objects.filter(slug=article_slug).update(
+                favourite_count=updated_favourites
+            )
+        else:
+            message = 'You have entered invalid data.'
+            raise exceptions.PermissionDenied(message)
+        return react_id
+
+    def validate(self, data):
+        try:
+            current_reaction = Reaction.objects.get(
+                article=data.get('article'),
+                user=data.get('user'),
+                reaction=data.get('reaction')
+            )
+            if isinstance(current_reaction, object):
+                message = 'You have already {}d this article.'.format(
+                    data.get('reaction').name
+                )
+                raise exceptions.ParseError(message)
+        except Reaction.DoesNotExist:
+            article = data.get('article')
+            reaction = data.get('reaction').id
+            react_id = ReactionSerializer.reaction_value(
+                reaction, article.slug, article, 1
+            )
+            if reaction == Impression.objects.get(name='Like').id:
+                react_id = 1
+                updated_likes = article.likes + 1
+                Article.objects.filter(slug=article.slug).update(
+                    likes=updated_likes
+                )
+            elif reaction == Impression.objects.get(name='Dislike').id:
+                react_id = 2
+                updated_dislikes = article.dislikes + 1
+                Article.objects.filter(slug=article.slug).update(
+                    dislikes=updated_dislikes
+                )
+            elif reaction == Impression.objects.get(name='Favourite').id:
+                react_id = 3
+                updated_favourites = article.favourite_count + 1
+                Article.objects.filter(slug=article.slug).update(
+                    favourite_count=updated_favourites
+                )
+            else:
+                message = 'You have entered invalid data.'
+                raise exceptions.PermissionDenied(message)
+            return {
+                'article': data.get('article'),
+                'reaction': react_id,
+                'user': data.get('user')
+            }
+
+    def create(self, validated_data):
+        user = self.context.get('user', None)
+        article = self.context.get('article', None)
+        reaction = self.context.get('reaction', None)
+        return Reaction.objects.create(
+            user=user, article=article, reaction=reaction
+        )

--- a/authors/apps/articles/tests.py
+++ b/authors/apps/articles/tests.py
@@ -1,8 +1,14 @@
+from io import StringIO
+
+from django.core.management import call_command
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from .models import Article
+from authors.apps.authentication.models import User
+from authors.apps.profiles.models import Profile
+
+from .models import Article, Impression, Reaction
 
 
 class ViewTest(TestCase):
@@ -14,11 +20,17 @@ class ViewTest(TestCase):
         self.email = "johndoe@gmail.com"
         self.password = "Password1"
 
-        self.user_data = {"user": {"username": self.username,
-                            "email": self.email,
-                            "password": self.password}}
+        self.user_data = {
+            "user": {
+                "username": self.username,
+                "email": self.email,
+                "password": self.password
+            }
+        }
 
-        self.response = self.client.post('/api/users/', self.user_data, format="json")
+        self.response = self.client.post(
+            '/api/users/', self.user_data, format="json"
+        )
 
         self.client.credentials(
             HTTP_AUTHORIZATION='Token ' + self.response.data['auth_token']
@@ -39,6 +51,14 @@ class ViewTest(TestCase):
         self.update_data = {'article': {'body': "This ought to work"}}
   
         self.response = self.client.post('/api/articles/', self.article,
+                                    format="json")
+        self.response1 = self.client.post('/api/articles/',
+                                     self.article, format="json")
+        self.response3 = self.client.post('/api/articles/', self.article_with_tags,
+                                    format="json")
+
+    def test_can_create_article(self):
+        response = self.client.post('/api/articles/', self.article,
                                     format="json")
         self.response1 = self.client.post('/api/articles/',
                                      self.article, format="json")
@@ -65,12 +85,12 @@ class ViewTest(TestCase):
         result = self.client.delete('/api/articles/{}/'
                                     .format(self.response.data['article']['slug']))
         self.assertEqual(result.status_code, status.HTTP_204_NO_CONTENT)        
-    
+
     def test_can_not_edit_unless_author(self):
         response = self.client.put('/api/articles/{}/'.format("no-work"),
                                    self.update_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-    
+
     def test_can_not_delete_unless_author(self):
         response = self.client.delete('/api/articles/{}/'.format("no-work"))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -91,3 +111,210 @@ class ViewTest(TestCase):
     def test_can_get_all_tags(self):
         result = self.client.get('/api/tags/')
         self.assertEqual(result.status_code, status.HTTP_200_OK)
+
+
+class ReactionViewTest(TestCase):
+
+    def setUp(self):
+        self.client = APIClient()
+
+        self.username = "johndoe"
+        self.email = "johndoe@gmail.com"
+        self.password = "Password1"
+
+        self.user_data = {
+            "user": {
+                "username": self.username,
+                "email": self.email,
+                "password": self.password
+            }
+        }
+
+        self.response = self.client.post(
+            '/api/users/', self.user_data, format="json"
+        )
+
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token {}'.format(self.response.data['auth_token'])
+        )
+
+        self.title = 'test article'
+        self.description = 'an article to test model'
+        self.body = 'This article will test our model'
+        self.slug = 'test-article'
+
+        self.article = {
+            'article': {
+                'title': self.title,
+                'description': self.description,
+                'body': self.body
+            }
+        }
+        self.client.post('/api/articles/', self.article, format="json")
+
+        populate_impression_table()
+
+        self.reactions = [
+            {'reaction': 'Like'},
+            {'reaction': 'Dislike'},
+            {'reaction': 'Favourite'}
+        ]
+        self.response = []
+        for reaction in self.reactions:
+            reaction_response = self.post_reaction(reaction)
+            self.response.append(reaction_response)
+
+    def post_reaction(self, reaction):
+        response = self.client.post(
+            '/api/articles/{0}/reaction/'.format(
+                self.slug
+            ), reaction, format="json"
+        )
+        return response
+
+    def test_can_react_to_an_article(self):
+        response_count = 0
+        for reaction in self.reactions:
+            self.assertEqual(
+                self.response[response_count].status_code, status.HTTP_200_OK
+            )
+            response_count += 1
+
+    def test_can_remove_reaction(self):
+        for reaction in self.reactions:
+            response = self.client.delete(
+                '/api/articles/{0}/reaction/'.format(self.slug),
+                reaction, format="json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_can_not_react_more_than_once(self):
+        for reaction in self.reactions:
+            response = self.post_reaction(reaction)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_can_not_remove_non_existing_reaction(self):
+        for reaction in self.reactions:
+            response = self.client.delete(
+                '/api/articles/{0}/reaction/'.format(self.slug),
+                reaction, format="json"
+            )
+            response = self.client.delete(
+                '/api/articles/{0}/reaction/'.format(self.slug),
+                reaction, format="json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)  
+
+
+class ReactionModelTest(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="raddish", email="rad@gmail.com", password="radredrad1"
+        )
+        self.old_count = Reaction.objects.count()
+        self.article = Article.objects.create(
+            title="my article", description="test",body="testing article"
+        )
+        self.reaction = Impression
+        self.like_impression = Impression.objects.create(
+            name='Like', description='Person finds the article appeasing'
+        )
+        self.dislike_impression = Impression.objects.create(
+            name='Dislike',
+            description='Person does not find the article to their liking'
+        )
+        self.favourite_impression = Impression.objects.create(
+            name='Favourite',
+            description="Person has found that they resonate with an article's words"
+        )
+        self.reactions = [self.like_impression, self.dislike_impression, self.favourite_impression]
+
+    def create_reaction(self, reaction):
+        Reaction.objects.create(
+            article=self.article, user=self.user, reaction=reaction
+        )
+
+    def test_model_can_react_to_article(self):
+        for reaction in self.reactions:
+            self.create_reaction(reaction=reaction)
+            self.new_count = Reaction.objects.count()
+            self.assertNotEqual(self.old_count, self.new_count)
+
+    def test_model_delete_reaction(self):
+        for reaction in self.reactions:
+            self.create_reaction(reaction=reaction)
+            reaction = Reaction.objects.get(
+                article=self.article, user=self.user, reaction=reaction
+            )
+            reaction.delete()
+            self.new_count = Reaction.objects.count()
+            self.assertEqual(self.old_count, self.new_count)
+
+
+class ArticlesModelTestCase(TestCase):
+    """Class with tests to do with interacting with the article model"""
+
+    def setUp(self):
+        """Define the test variables"""
+        self.user = User.objects.create_user(
+            username="red", email="red@gmail.com", password="password"
+        )
+        self.profile = Profile.objects.get(user=self.user)
+        self.old_count = Article.objects.count()
+        self.article = Article.objects.create(
+            title="Test article",
+            description="description of test article",
+            body="this is the body of test article",
+            author=self.profile
+        )
+
+    def test_creation_of_article(self):
+        """Test that an article can be created."""
+        self.new_count = Article.objects.count()
+        self.assertNotEqual(self.old_count, self.new_count)
+
+    def test_get_an_article_by_anyone(self):
+        """Test that an article can be returned."""
+        article = self.article.get_article('test-article')
+        self.assertEqual(article.description, "description of test article")
+
+    def test_an_article_can_be_deleted(self):
+        """Test that an article can be deleted."""
+        self.article.delete_article(self.user.email, 'test-article')
+        self.new_count = Article.objects.count()
+        self.assertEqual(self.old_count, self.new_count)
+
+
+    def test_get_article_by_authenticated_user(self):
+        """Test that an authenticated user can get an article"""
+        protected_article = self.article.get_user_article(
+            self.user.email, 'test-article'
+        )
+        self.assertEqual(protected_article.description, "description of test article")
+
+
+class TestPopulateTable(TestCase):
+    def test_table_is_populated(self):
+        out = StringIO()
+        call_command('populate_impression', stdout=out)
+        self.assertIn('Impression Table has been populated', out.getvalue())
+
+    def test_table_has_already_been_populated(self):
+        out = StringIO()
+        populate_impression_table()
+        call_command('populate_impression', stdout=out)
+        self.assertIn('No need to populate Impression table.', out.getvalue())
+
+def populate_impression_table():
+    impressions = [
+        {'Like': 'Person finds the article appeasing'},
+        {'Dislike': 'Person does not find the article to their liking'},
+        {'Favourite': "Person has found that they resonate with an article's words"}
+    ]
+    for impression in impressions:
+        for key in impression:
+            Impression.objects.create(
+                name=key,
+                description=impression[key]
+            ).save()

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
 
-from .views import CreateArticle, ArticleRetrieveUpdate, ArticleList, TagList
+from .views import (
+    CreateArticle,
+    ArticleRetrieveUpdate,
+    ArticleList,
+    ReactionView,
+    TagList
+    )
 
 urlpatterns = [
     path('articles/', CreateArticle.as_view()),
     path('articles/<str:slug>/', ArticleRetrieveUpdate.as_view()),
     path('article/', ArticleList.as_view()),
-    path('tags/', TagList.as_view())
+    path('tags/', TagList.as_view()),
+    path('articles/<str:slug>/reaction/', ReactionView.as_view())
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,27 +1,39 @@
 from authors.apps.authentication.backends import JWTAuthentication
-from rest_framework import generics, status
+from rest_framework import (
+    exceptions,
+    generics,
+    status
+)
 from rest_framework.permissions import (
     IsAuthenticatedOrReadOnly,
-    IsAuthenticated
+    IsAuthenticated,
+    AllowAny
 )
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .models import (
     Article,
+    Reaction,
+    Impression,
     Tag
 )
 from authors.apps.profiles.serializers import ProfileSerializer
-from .renderers import ArticleJSONRenderer
+
+from .renderers import (
+    ArticleJSONRenderer,
+    ReactionJSONRenderer
+)
 from .serializers import (
     ArticleSerializer,
+    ReactionSerializer,
     TagSerializer
 )
 
 
 class CreateArticle(generics.CreateAPIView):
     """Class for creation of an article"""
-    
+
     serializer_class = ArticleSerializer
     renderer_class = (ArticleJSONRenderer,)
     permission_classes = (IsAuthenticated,)
@@ -67,6 +79,9 @@ class ArticleRetrieveUpdate(APIView):
                              "createdAt": serializer.data['createdAt'],
                              "updatedAt": serializer.data['updatedAt'],
                              "slug": serializer.data['slug'],
+                             "fav_count": serializer.data['favourite_count'],
+                             "likes": serializer.data['likes'],
+                             "dislikes": serializer.data['dislikes'],
                              "tagList": serializer.data['tagList'],
                             },
                  "message": "Success"
@@ -126,3 +141,101 @@ class TagList(generics.ListAPIView):
             'tags': serializer.data
         }, status=status.HTTP_200_OK)
         
+
+class ReactionView(APIView):
+    """Class to like or dislike an article"""
+
+    serializer_class = ReactionSerializer
+    renderer_class = (ReactionJSONRenderer,)
+    permission_classes = (IsAuthenticated,)
+
+    def check_reaction(self, reaction_data, request):
+
+        like_verb = 'liked'
+        dislike_verb = 'disliked'
+        fav_verb = 'added'
+        to_from = 'to'
+        message = dict()
+        if request.method == 'DELETE':
+            like_verb = 'unliked'
+            dislike_verb = 'removed the dislike from'
+            fav_verb = 'removed'
+            to_from = 'from'
+
+        if reaction_data == 'Like':
+            message = {
+                'Message': 'You have {} this article'.format(like_verb)
+            }
+        elif reaction_data == 'Dislike':
+            message = {
+                'Message': 'You have {} this article'.format(dislike_verb)
+            }
+        elif reaction_data == 'Favourite':
+            message = {
+                'Message':
+                'You have {0} this article {1} your favourites'.format(
+                    fav_verb, to_from
+                )
+            }
+        return message
+
+    def check_validation(self, slug, request):
+        username = request.user.username
+        article = Article.get_article(slug=slug)
+        impression = Impression.objects.get(name=request.data.get('reaction'))
+        serializer_data = {}
+        serializer_context = {
+            'user': request.user,
+            'article': article,
+            'reaction': Impression.objects.get(
+                name=request.data.get('reaction')
+                ),
+            }
+        serializer_data['reaction'] = impression.id
+        serializer_data['user'] = request.user.id
+        serializer_data['article'] = article.id
+        serializer = self.serializer_class(
+            data=serializer_data, context=serializer_context
+        )
+        serializer.is_valid(raise_exception=True)
+        return serializer
+
+    def post(self, request, slug):
+        serializer = self.check_validation(slug, request)
+        message = self.check_reaction(
+            request.data.get('reaction'),
+            request
+        )
+
+        serializer.save()
+
+        return Response(
+            message,
+            status=status.HTTP_200_OK
+        )
+
+    def delete(self, request, slug):
+
+        try:
+            article = Article.get_article(slug=slug)
+            reaction= Impression.objects.get(
+                name=request.data['reaction']
+            )
+            reaction = Reaction.objects.get(
+                article=article.id,
+                user=request.user.id,
+                reaction=reaction
+            )
+            message = self.check_reaction(
+                request.data['reaction'],
+                request
+            )
+            ReactionSerializer.reaction_value(
+                reaction.id, article.slug, article, -1
+            )
+            reaction.delete()
+            return Response(message, status=status.HTTP_204_NO_CONTENT)
+
+        except Reaction.DoesNotExist:
+            message = 'You have not yet interacted with this article'
+            raise exceptions.ParseError(message)


### PR DESCRIPTION
#### What does this PR do?

Users can like and unlike an article
Users can favourite or unfavourite an article
#### Description of Task to be completed?

Currently, users can not like or favourite articles

This task allows authenticated users to like, dislike, favourite and remove an article from the favourites list.


#### How should this be manually tested?

Make migrations: `python manage.py makemigrations articles`
Migrate: `python manage.py migrate`
Populate impression table: `python manage.py populate_impression`
Run the server: `python manage.py runserver`
Open postman and test these endpoints with the data below:
```
{
    "reaction": "<Like/Dislike/Favourite>"
}
``` 

**Note**; All endpoints are authenticated

**Like, dislike or favourite an article** 
POST `http://127.0.0.1:8000/api/articles/<slug>/reaction/`


**Remove a like, dislike or favourite from article**
DELETE `http://127.0.0.1:8000/api/articles/<slug>/reaction/`


#### What are the relevant pivotal tracker stories?

[#160609560](https://www.pivotaltracker.com/story/show/160609560)

[#160609558](https://www.pivotaltracker.com/story/show/160609558)

#### Any background context you want to add?
N/A

