### PR TITLE
#160609564 Create tags for articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -17,6 +17,9 @@ class Article(models.Model):
     body = models.TextField(null=True)
     createdAt = models.DateTimeField(auto_now_add=True, null=True)
     updatedAt = models.DateTimeField(auto_now=True, null=True)
+    tags = models.ManyToManyField(
+        'articles.Tag', related_name='articles'
+    )
 
     @staticmethod
     def get_article(slug):
@@ -74,3 +77,15 @@ class Article(models.Model):
         if not self.slug:
             self.slug = self._get_unique_slug()
         super().save(*args, **kwargs)
+
+
+class Tag(models.Model):
+    """Model for tags """
+    
+    tag = models.CharField(max_length=255)
+    createdAt = models.DateTimeField(auto_now_add=True, null=True)
+    updatedAt = models.DateTimeField(auto_now=True, null=True)
+    
+    def __str__(self):
+        return self.tag
+        

--- a/authors/apps/articles/relations.py
+++ b/authors/apps/articles/relations.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from .models import Tag
+
+class TagRelatedField(serializers.RelatedField):
+    """Class for Tag RelatedField"""
+
+    def to_internal_value(self, data):
+        """To implement a read-write relational field"""
+        tag, created = Tag.objects.get_or_create(tag=data)
+        return tag
+
+    def to_representation(self, value):
+        """Override the RelationField """
+        return value.tag

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,18 +1,38 @@
 from rest_framework import serializers
 
-from .models import Article
+from .models import (
+    Article,
+    Tag
+)
+from .relations import TagRelatedField
 
 
 class ArticleSerializer(serializers.ModelSerializer):
     """Create a new article"""
 
+    tagList = TagRelatedField(many=True, required=False, queryset=Tag.objects.all(), source='tags')
+
     class Meta:
         model = Article
         fields = [
             'author', 'title', 'description', 'body',
-            'createdAt', 'updatedAt', 'slug'
+            'createdAt', 'updatedAt', 'slug', 'tagList'
         ]
 
     def create(self, validated_data):
         author = self.context.get('author', None)
-        return Article.objects.create(author=author, **validated_data)
+        tags_data = validated_data.pop('tags', [])
+        article = Article.objects.create(author=author, **validated_data)
+        for tag in tags_data:
+            article.tags.add(tag)
+        return article
+
+
+class TagSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Tag
+        fields = ('tag',)
+
+    def to_representation(self, value):
+        return value.tag

--- a/authors/apps/articles/tests.py
+++ b/authors/apps/articles/tests.py
@@ -27,38 +27,43 @@ class ViewTest(TestCase):
         self.title = 'test article'
         self.description = 'an article to test model'
         self.body = 'This article will test our model'
+        self.tagList = [ "articles", "authors", "TEST"]
 
         self.article = {'article': {'title': self.title,
                                     'description': self.description,
                                     'body': self.body}}
+        self.article_with_tags = {'article': {'title': self.title,
+                                    'description': self.description,
+                                    'body': self.body,
+                                    'tagList': self.tagList}}
         self.update_data = {'article': {'body': "This ought to work"}}
   
-    
-    def test_can_create_article(self):
-        response = self.client.post('/api/articles/', self.article,
+        self.response = self.client.post('/api/articles/', self.article,
                                     format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.response1 = self.client.post('/api/articles/',
+                                     self.article, format="json")
+        self.response3 = self.client.post('/api/articles/', self.article_with_tags,
+                                    format="json")
+    def test_can_create_article(self):
+        self.assertEqual(self.response.status_code, status.HTTP_201_CREATED)
+
+    def test_can_create_article_with_tags(self):
+        self.assertEqual(self.response3.status_code, status.HTTP_201_CREATED)
 
     def test_can_get_article(self):
-        response = self.client.post('/api/articles/', self.article,
-                                    format="json")
         result = self.client.get('/api/articles/{}/'
-                                 .format(response.data['article']['slug']))
+                                 .format(self.response.data['article']['slug']))
         self.assertEqual(result.status_code, status.HTTP_200_OK)
 
     def test_can_update_article(self):
-        response = self.client.post('/api/articles/', self.article,
-                                    format="json")
         result = self.client.put('/api/articles/{}/'
-                                 .format(response.data['article']['slug']),
+                                 .format(self.response.data['article']['slug']),
                                  self.update_data, format="json")
         self.assertEqual(result.status_code, status.HTTP_200_OK)
 
     def test_can_delete_article(self):
-        response = self.client.post('/api/articles/', self.article,
-                                    format="json")
         result = self.client.delete('/api/articles/{}/'
-                                    .format(response.data['article']['slug']))
+                                    .format(self.response.data['article']['slug']))
         self.assertEqual(result.status_code, status.HTTP_204_NO_CONTENT)        
     
     def test_can_not_edit_unless_author(self):
@@ -71,11 +76,7 @@ class ViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_can_create_unique_slug(self):
-        response = self.client.post('/api/articles/',
-                                    self.article, format="json")
-        response1 = self.client.post('/api/articles/',
-                                     self.article, format="json")
-        self.assertNotEqual(response, response1)
+        self.assertNotEqual(self.response, self.response1)
 
     def test_can_get_all_articles(self):
         self.client.post('/api/articles/', self.article, format="json")
@@ -86,3 +87,7 @@ class ViewTest(TestCase):
     def test_cannot_get_article_that_doesnot_exist(self):
         response = self.client.get('/api/articles/{}/'.format("no-work-here"))
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_can_get_all_tags(self):
+        result = self.client.get('/api/tags/')
+        self.assertEqual(result.status_code, status.HTTP_200_OK)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import CreateArticle, ArticleRetrieveUpdate, ArticleList
+from .views import CreateArticle, ArticleRetrieveUpdate, ArticleList, TagList
 
 urlpatterns = [
     path('articles/', CreateArticle.as_view()),
     path('articles/<str:slug>/', ArticleRetrieveUpdate.as_view()),
-    path('article/', ArticleList.as_view())
+    path('article/', ArticleList.as_view()),
+    path('tags/', TagList.as_view())
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,13 +1,22 @@
 from authors.apps.authentication.backends import JWTAuthentication
 from rest_framework import generics, status
-from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
+from rest_framework.permissions import (
+    IsAuthenticatedOrReadOnly,
+    IsAuthenticated
+)
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .models import Article
+from .models import (
+    Article,
+    Tag
+)
 from authors.apps.profiles.serializers import ProfileSerializer
 from .renderers import ArticleJSONRenderer
-from .serializers import ArticleSerializer
+from .serializers import (
+    ArticleSerializer,
+    TagSerializer
+)
 
 
 class CreateArticle(generics.CreateAPIView):
@@ -57,7 +66,8 @@ class ArticleRetrieveUpdate(APIView):
                              "body": serializer.data['body'],
                              "createdAt": serializer.data['createdAt'],
                              "updatedAt": serializer.data['updatedAt'],
-                             "slug": serializer.data['slug']
+                             "slug": serializer.data['slug'],
+                             "tagList": serializer.data['tagList'],
                             },
                  "message": "Success"
                  },
@@ -100,3 +110,19 @@ class ArticleList(generics.ListAPIView):
     def get_queryset(self):
         queryset = Article.objects.all()
         return queryset
+
+
+class TagList(generics.ListAPIView):
+    """Class to get a list of existing tags"""
+
+    queryset = Tag.objects.all()
+    permission_classes = (IsAuthenticated,)
+    serializer_class = TagSerializer
+
+    def list(self, request):
+        serializer_data = self.get_queryset()
+        serializer = self.serializer_class(serializer_data, many=True)
+        return Response({
+            'tags': serializer.data
+        }, status=status.HTTP_200_OK)
+        


### PR DESCRIPTION
### What does this PR do?

Add feature to add tags to an article

#### Description of Task to be completed?

Currently, the articles created have no tags. 

This task ensures that users are able to create tags for the articles that they author. We can also retrieve a list of tags used so far.

#### How should this be manually tested?

Make migrations ```python manage.py makemigrations```
Migrate ```python manage.py migrate```
Run the server ```python manage.py runserver```
Open postman and login to an existing user account. Copy the token from the login result.
Enter the URL ```POST http://127.0.0.1:8000/api/articles/```. Add an authentication header with a token got from logging in.
In the body put details below and POST

{
  "article": {
    	"title": "Jess is here for us",
    	"description": "Our new COO",
    	"tagList": [ "COO", "ops", "newyork"],
    	"body": "I am testing to confirm"
	}
}

To retrieve existing tags, enter the URL ```GET http://127.0.0.1:8000/api/tags/```

#### What are the relevant pivotal tracker stories?

- [#160609564](https://www.pivotaltracker.com/story/show/160609564)

#### Screenshots (if appropriate)

<img width="595" alt="screen shot 2018-10-11 at 16 09 19" src="https://user-images.githubusercontent.com/31615608/46806537-7fdcad00-cd70-11e8-8a2e-6429ccd13af8.png">

<img width="549" alt="screen shot 2018-10-11 at 16 10 07" src="https://user-images.githubusercontent.com/31615608/46806603-b1ee0f00-cd70-11e8-8c68-202de0767d65.png">
