### PR TITLE
#160609565 Add pagination of articles

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -154,5 +154,8 @@ REST_FRAMEWORK = {
        'authors.apps.authentication.backends.JWTAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated', )
+        'rest_framework.permissions.IsAuthenticated', 
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 5,
 }


### PR DESCRIPTION
### What does this PR do?

Enable pagination of retrieved articles

#### Description of Task to be completed?

Currently, Pagination support is lacking for our articles.

This task adds pagination support for retrieved articles using Django Rest Framework `PageNumberPagination`


#### How should this be manually tested?

Make migrations: `python manage.py makemigrations articles`
Migrate: `python manage.py migrate` 
Run the server: `python manage.py runserver`

Open postman and GET `http://127.0.0.1:8000/api/article/` to retrieve all the articles.

The `count` of total number of articles is shown but only 5 of those articles are displayed

To view more articles, copy the url in the `next` field into postman and run a GET

To view the previous articles, copy the url in the `previous` field into postman and run a GET

#### What are the relevant pivotal tracker stories?

- [#160609565](https://www.pivotaltracker.com/story/show/160609565)

#### Screenshots (if appropriate)
<img width="1051" alt="first pqge" src="https://user-images.githubusercontent.com/31615608/46953678-2be70680-d097-11e8-9b2a-66d629844587.png">

<img width="1035" alt="last" src="https://user-images.githubusercontent.com/31615608/46953851-aa43a880-d097-11e8-8f55-6d643a01bde4.png">

