### PR TITLE
#160609567 show the reading time for an article's body

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -23,6 +23,7 @@ class Article(models.Model):
     likes = models.PositiveIntegerField(default=0)
     dislikes = models.PositiveIntegerField(default=0)
     favourite_count = models.PositiveIntegerField(default=0)
+    reading_time = models.CharField(max_length=100, null=True)
 
     @staticmethod
     def get_article(slug):
@@ -49,6 +50,24 @@ class Article(models.Model):
             message = "You are not authenticated for the action"
             raise exceptions.PermissionDenied(message)
         return article.delete()
+
+    @staticmethod
+    def article_reading_time(body):
+        new_line_words = body.split('\n')
+
+        total_words = 0
+        for group in new_line_words:
+            total_words += len(group.split())
+
+        # Assume a reading time of 275WPM
+        time_to_read = (total_words/275)
+        if time_to_read < 1:
+            return 'Less than a minute'
+        elif time_to_read < 2:
+            return 'About 1 minute'
+
+        # Return a value rounded up or down if below or above 5
+        return str(int(round(time_to_read))) + ' minutes'
 
     @staticmethod
     def get_profile(profile_id):

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -12,9 +12,9 @@ class ArticleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Article
         fields = [
-            'author', 'title', 'description',
-            'body', 'createdAt', 'updatedAt',
-            'slug', 'favourite_count', 'likes', 'dislikes', 'tagList'
+            'author', 'title', 'description', 'body',
+            'createdAt', 'updatedAt', 'slug', 'favourite_count',
+            'likes', 'dislikes', 'tagList', 'reading_time'
         ]
 
     def create(self, validated_data):

--- a/authors/apps/articles/tests.py
+++ b/authors/apps/articles/tests.py
@@ -318,3 +318,19 @@ def populate_impression_table():
                 name=key,
                 description=impression[key]
             ).save()
+
+
+class TestReadingTime(TestCase):
+    body = "one two three\n four five six \n"
+
+    def test_correct_time_returned(self):
+        time = Article.article_reading_time(self.body * 200)
+        self.assertEqual(time, '4 minutes')
+
+    def test_correct_time_less_than_2_minutes(self):
+        time = Article.article_reading_time(self.body * 75)
+        self.assertEqual(time, 'About 1 minute')
+
+    def test_correct_time_less_than_1_minute(self):
+        time = Article.article_reading_time(self.body * 20)
+        self.assertEqual(time, 'Less than a minute')

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -18,6 +18,7 @@ from .models import (
     Impression,
     Tag
 )
+from authors.apps.authentication.backends import JWTAuthentication
 from authors.apps.profiles.serializers import ProfileSerializer
 
 from .renderers import (
@@ -43,6 +44,8 @@ class CreateArticle(generics.CreateAPIView):
         serializer_context = {'author': request.user.profile}
         serializer_data = request.data.get('article', {})
 
+        time_to_read = Article.article_reading_time(serializer_data['body'])
+        serializer_data['readingTime'] = time_to_read
         serializer = self.serializer_class(data=serializer_data,
                                            context=serializer_context)
 
@@ -83,6 +86,7 @@ class ArticleRetrieveUpdate(APIView):
                              "likes": serializer.data['likes'],
                              "dislikes": serializer.data['dislikes'],
                              "tagList": serializer.data['tagList'],
+                             "reading_time": serializer.data['reading_time']
                             },
                  "message": "Success"
                  },


### PR DESCRIPTION
### What does this PR do?
Show the time it will take to read an article

#### Description of Task to be completed?
Currently, readers can not see the estimated time it will take to read an article.
This feature displays the time it takes to read an article.

#### How should this be manually tested?
- Make migrations: python manage.py makemigrations articles.
- Migrate: python manage.py migrate.
- Run the server: python manage.py runserver.
- Open postman and post an article in the format below using a registered user ;
```
{
  "article": {
    	"title": "Testing django part 13",
    	"description": "It should work",
    	"body": "I am testing to confirm"
	}
}
```
-The readingTime should be shown as a field in the article returned in the response.

#### What are the relevant pivotal tracker stories?
[#160609567](https://www.pivotaltracker.com/story/show/160609567)