### PR TITLE
#160609557 comment on articles

### DIFF
--- a/authors/apps/articles/exceptions.py
+++ b/authors/apps/articles/exceptions.py
@@ -1,0 +1,14 @@
+"""
+Class to handle exceptions
+"""
+
+from rest_framework.exceptions import APIException
+
+
+class NotFoundException(APIException):
+    """
+    Provides 404 not found error
+    """
+    default_code = "not_found"
+    default_detail = "The requested resource was not found."
+    status_code = 404

--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -1,6 +1,8 @@
 import json
 from rest_framework.renderers import JSONRenderer
 
+from authors.apps.core.renderers import AuthorsJSONRenderer
+
 
 class ArticleJSONRenderer(JSONRenderer):
     """Class for JSON renderer for Artiles app"""
@@ -24,3 +26,13 @@ class ReactionJSONRenderer(JSONRenderer):
         :return JSON object with key reaction"""
 
         return json.dumps({'reaction': data})
+
+
+class CommentJSONRenderer(AuthorsJSONRenderer):
+    """Renderer for the comments"""
+    object_label = 'comments'
+
+
+class ThreadJSONRenderer(AuthorsJSONRenderer):
+    """Renderer for the comments"""
+    object_label = 'thread'

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,6 +1,12 @@
 from rest_framework import exceptions, serializers
 
-from .models import Article, Impression, Reaction, Tag
+from .models import (
+    Article,
+    Impression,
+    Reaction,
+    Tag,
+    Comment
+)
 from .relations import TagRelatedField
 
 
@@ -14,7 +20,7 @@ class ArticleSerializer(serializers.ModelSerializer):
         fields = [
             'author', 'title', 'description', 'body',
             'createdAt', 'updatedAt', 'slug', 'favourite_count',
-            'likes', 'dislikes', 'tagList', 'reading_time'
+            'likes', 'dislikes', 'tagList', 'reading_time', 'comment_count'
         ]
 
     def create(self, validated_data):
@@ -119,5 +125,26 @@ class ReactionSerializer(serializers.ModelSerializer):
         article = self.context.get('article', None)
         reaction = self.context.get('reaction', None)
         return Reaction.objects.create(
-            user=user, article=article, reaction=reaction
+            user=user, article=article, reaction=reaction)
+
+
+class CommentSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Comment
+        fields = [
+            'id', 'author', 'article', 'body',
+            'parent', 'created_at', 'updated_at', 'thread_count'
+        ]
+
+    def create(self, validated_data):
+        author = self.context.get('author', None)
+        article = self.context.get('article', None)
+        parent = self.context.get('parent', None)
+
+        return Comment.objects.create(
+            author=author,
+            article=article,
+            parent=parent,
+            **validated_data
         )

--- a/authors/apps/articles/tests.py
+++ b/authors/apps/articles/tests.py
@@ -334,3 +334,183 @@ class TestReadingTime(TestCase):
     def test_correct_time_less_than_1_minute(self):
         time = Article.article_reading_time(self.body * 20)
         self.assertEqual(time, 'Less than a minute')
+
+
+class ViewTestComments(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.username = "johndoe"
+        self.email = "johndoe@gmail.com"
+        self.password = "Password1"
+        self.user_data = {
+            "user": {
+                "username": self.username,
+                "email": self.email,
+                "password": self.password
+            }
+        }
+        self.response = self.client.post(
+            '/api/users/', self.user_data, format="json"
+        )
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token {}'.format(self.response.data['auth_token'])
+        )
+        self.title = 'test article'
+        self.description = 'an article to test model'
+        self.body = 'This article will test our model'
+        self.article = {
+            'article': {
+                'title': self.title,
+                'description': self.description,
+                'body': self.body
+            }
+        }
+
+        self.comment_body = "this is my comment"
+
+        self.comment = {
+            "comment": {
+                "body": self.comment_body
+            }
+        }
+
+        self.thread = {
+            "comment": {
+                "body": "lets start a thread one"
+            }
+        }
+
+        self.create_article = self.client.post(
+            '/api/articles/', self.article, format="json"
+        )
+
+        self.create_comment = self.client.post(
+            '/api/articles/{}/comments/'.format(
+                self.create_article.data['article']['slug']
+            ),
+            self.comment, format="json"
+        )
+
+        self.create_thread = self.client.post(
+            '/api/articles/{}/comments/{}/thread/'.format(
+                self.create_article.data['article']['slug'],
+                self.create_comment.data['id']
+            ),
+            self.thread, format="json"
+        )
+
+    def test_comment_creation(self):
+        self.assertEqual(
+            self.create_comment.status_code,status.HTTP_201_CREATED
+        )
+
+    def test_comment_retrieval(self):
+        result = self.client.get(
+            '/api/articles/{}/comments/'.format(
+                self.create_article.data['article']['slug']
+            )
+        )
+        self.assertEqual(result.status_code, status.HTTP_200_OK)
+
+    def test_comment_update(self):
+        result = self.client.put(
+            '/api/articles/{}/comments/{}/'.format(
+                self.create_article.data['article']['slug'],
+                self.create_comment.data['id']
+            ),
+            self.comment, format="json"
+        )
+        self.assertEqual(result.status_code, status.HTTP_200_OK)
+
+    def test_comment_delete(self):
+        result = self.client.delete(
+            '/api/articles/{}/comments/{}/'.format(
+                self.create_article.data['article']['slug'],
+                self.create_comment.data['id']
+            )
+        )
+        self.assertEqual(result.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIn("comment has been deleted successfully",
+                      str(result.data['message']))
+    
+    def test_comment_delete_with_non_existent_article(self):
+        result = self.client.delete(
+            '/api/articles/no_article/comments/{}/'.format(
+                self.create_comment.data['id']
+            )
+        )
+        self.assertEqual(result.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("The Article does not exist",
+                      str(result.data['detail']))
+
+    def test_thread_creation(self):
+        result = self.client.post(
+            '/api/articles/{}/comments/{}/thread/'.format(
+                self.create_article.data['article']['slug'],
+                self.create_comment.data['id']
+            ),
+            self.thread, format="json"
+        )
+        self.assertEqual(result.status_code, status.HTTP_201_CREATED)
+
+    def test_thread_retrieval(self):
+        result = self.client.get(
+            '/api/articles/{}/comments/{}/thread/'.format(
+                self.create_article.data['article']['slug'],
+                self.create_comment.data['id']
+            )
+        )
+        self.assertEqual(result.status_code, status.HTTP_200_OK)
+
+    def test_create_comment_for_non_existent_article(self):
+        result = self.client.post(
+            '/api/articles/non-existent/comments/',
+            self.comment, format="json"
+        )
+        self.assertEqual(result.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("The Article does not exist", str(result.data['detail']))
+
+    def test_update_non_existent_comment(self):
+        result = self.client.put(
+            '/api/articles/{}/comments/{}/'.format(
+                self.create_article.data['article']['slug'], int(100)
+            ),
+            self.comment, format="json"
+        )
+        self.assertEqual(result.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("The comment does not exist", str(result.data['detail']))
+
+    def test_thread_creation_with_non_existent_article(self):
+        result = self.client.post(
+            '/api/articles/no-article/comments/{}/thread/'.format(
+                self.create_comment.data['id']
+            ),
+            self.thread, format="json"
+        )
+        self.assertEqual(result.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("The Article does not exist", str(result.data['detail']))
+
+    def test_thread_creation_with_non_existent_parent_comment(self):
+        result = self.client.post(
+            '/api/articles/{}/comments/{}/thread/'.format(
+                self.create_article.data['article']['slug'], int(30)
+            ),
+            self.thread, format="json"
+        )
+        self.assertEqual(result.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("The parent comment does not exist",
+                      str(result.data['detail']))
+
+    def test_thread_creation_with_another_thread_as_parent(self):
+        result = self.client.post(
+            '/api/articles/{}/comments/{}/thread/'.format(
+                self.create_article.data['article']['slug'],
+                self.create_thread.data['id']
+            ),
+            self.thread, format="json"
+        )
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            "Parent comment is already a sub comment",
+            str(result.data['message'])
+        )

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -5,13 +5,23 @@ from .views import (
     ArticleRetrieveUpdate,
     ArticleList,
     ReactionView,
-    TagList
-    )
+    TagList,
+    CommentListCreateAPIView,
+    CommentRetrieveUpdateDestroyAPIView,
+    ThreadListCreateAPIView
+)
 
 urlpatterns = [
     path('articles/', CreateArticle.as_view()),
     path('articles/<str:slug>/', ArticleRetrieveUpdate.as_view()),
     path('article/', ArticleList.as_view()),
     path('tags/', TagList.as_view()),
-    path('articles/<str:slug>/reaction/', ReactionView.as_view())
+    path('articles/<str:slug>/reaction/', ReactionView.as_view()),
+    path('articles/<str:slug>/comments/', CommentListCreateAPIView.as_view()),
+    path('articles/<str:slug>/comments/<str:id>/',
+         CommentRetrieveUpdateDestroyAPIView.as_view()
+         ),
+    path('articles/<str:slug>/comments/<int:id>/thread/',
+         ThreadListCreateAPIView.as_view()
+         ),
 ]

--- a/authors/apps/core/renderers.py
+++ b/authors/apps/core/renderers.py
@@ -1,17 +1,23 @@
 import json
-
 from rest_framework.renderers import JSONRenderer
+from rest_framework.utils.serializer_helpers import (
+    ReturnDict,
+    ReturnList
+)
 
 class AuthorsJSONRenderer(JSONRenderer):
     charset = 'utf-8'
     object_label = 'object'
-
+    
     def render(self, data, media_type=None, renderer_context=None):
-        errors = data.get('errors', None)
+        """Method to convert data to a specific format"""
+        if type(data) != ReturnList:
+            errors = data.get('errors', None)
+            if errors is not None:
+                return super(AuthorsJSONRenderer, self).render(data)
 
-        if errors is not None:
-            return super(AuthorsJSONRenderer, self).render(data)
-        
-        return json.dumps({
-            self.object_label: data
-        })
+        if type(data) == ReturnDict:
+            return json.dumps({self.object_label: data})
+
+        else:
+            return json.dumps({self.object_label: data})


### PR DESCRIPTION
### What does this PR do?

Allows logged in users to create comments on articles and send replies to those comments.

### Description of tasks to be completed?

Currently, a user cannot comment on an article.
This PR adds functionality to allow logged in users to comment on articles and also add replies to comments

### How should this be manually tested?

Make migrations `python manage.py makemigrations` and `python manage.py migrate`
Run the server `python manage.py runserver`

NB: Please check the background context section before proceeding

***Create a comment***
Open postman and copy this URL POST `http://127.0.0.1:8000/api/articles/article-1/comments/`.
Add a comment body in the format shown below:
```
{
	"comment": {
		"body": "this is a comment, a what, a comment, a what, a comment, oh!  a comment"
	}
}
```
A comment should be created and its details should be returned.

***Retreive comments***
 GET `http://127.0.0.1:8000/api/articles/article-1/comments/` in Postman.
Comments created should be returned.

***Edit a comment***
PUT `http://127.0.0.1:8000/api/articles/article-1/comments/1/` in postman
Add a comment body in the format shown below:
```
{
	"comment": {
		"body": "Edited comment"
	}
}
```
The comment should be edited and the edited body should be returned.

***Delete a comment***
DELETE `http://127.0.0.1:8000/api/articles/article-1/comments/1/` in postman
The comment should be deleted and you should get a message saying that the comment was deleted successfully.

***Post a thread to a comment***
POST `http://127.0.0.1:8000/api/articles/article-1/comments/1/thread/` in postman
Add a comment body in the format shown below:
```
{
	"comment": {
		"body": "This is a comment reply"
	}
}
```
The thread should be created and the thread details should be returned.

***Retrieve a thread of replies to a comment***
GET `http://127.0.0.1:8000/api/articles/article-1/comments/1/thread/` in postman
The thread of replies should be returned.


### What are the relevant pivotal tracker stories?

[#160609557](https://www.pivotaltracker.com/story/show/160609557)

### Any background context you want to add?

Ensure to login (all endpoints concerning comments are secured) and have an article created before proceeding to create a comment.
Create an article with the title "article 1" in order to proceed with manual testing of this PR.

### Screenshots
*Response from creating a comment*
<img width="1103" alt="post a comment" src="https://user-images.githubusercontent.com/38077368/47084833-71354080-d21d-11e8-85bc-e21667036a2d.png">

*Response from getting comments*
<img width="1101" alt="get comments" src="https://user-images.githubusercontent.com/38077368/47084879-89a55b00-d21d-11e8-9f46-a54e3fd2d565.png">

*Response from editing a comment*
<img width="1101" alt="edit comment" src="https://user-images.githubusercontent.com/38077368/47084900-9e81ee80-d21d-11e8-81b3-ccdc97e5a675.png">

*Response from deleting a comment*
<img width="1104" alt="delete comment" src="https://user-images.githubusercontent.com/38077368/47084929-b48faf00-d21d-11e8-940e-5023e74fa573.png">

*Response from creating a thread*
<img width="1102" alt="thread to a comment" src="https://user-images.githubusercontent.com/38077368/47084963-d25d1400-d21d-11e8-8578-aa06c1916bf3.png">

*Response from getting a thread to a comment*
<img width="1094" alt="retrieve a thread" src="https://user-images.githubusercontent.com/38077368/47084996-e739a780-d21d-11e8-9274-508e8a3e7725.png">
