### PR TITLE
#160609568 Users should be able to share articles across different channels

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -148,3 +148,9 @@ class CommentSerializer(serializers.ModelSerializer):
             parent=parent,
             **validated_data
         )
+
+
+
+class ShareArticleSerializer(serializers.Serializer):
+    content = serializers.CharField()
+    share_with = serializers.CharField()

--- a/authors/apps/articles/tests.py
+++ b/authors/apps/articles/tests.py
@@ -27,6 +27,24 @@ class ViewTest(TestCase):
                 "password": self.password
             }
         }
+        self.share_data = {
+            "article": {
+                "share_with": "kakaemma1@gmail.com",
+                "content": "music-in-town"
+            }
+        }
+        self.invalid_email = {
+            "article": {
+                "share_with": "kakaemma.com",
+                "content": "music-in-town"
+            }
+        }
+        self.no_content = {
+            "article": {
+                "share_with": "",
+                "content": ""
+            }
+        }
 
         self.response = self.client.post(
             '/api/users/', self.user_data, format="json"
@@ -56,6 +74,10 @@ class ViewTest(TestCase):
                                      self.article, format="json")
         self.response3 = self.client.post('/api/articles/', self.article_with_tags,
                                     format="json")
+                                    
+    def method_to_call_on_route(self, end_point, endpoint_data):
+        response = self.client.post(end_point, endpoint_data, format="json" )
+        return response
 
     def test_can_create_article(self):
         response = self.client.post('/api/articles/', self.article,
@@ -111,6 +133,18 @@ class ViewTest(TestCase):
     def test_can_get_all_tags(self):
         result = self.client.get('/api/tags/')
         self.assertEqual(result.status_code, status.HTTP_200_OK)
+
+    def test_share_article(self):
+        resp = self.method_to_call_on_route('/api/article/share/', self.share_data)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_share_article_with_invalid_email(self):
+        response = self.method_to_call_on_route('/api/article/share/', self.invalid_email)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_share_article_with_no_content(self):
+        response = self.method_to_call_on_route('/api/article/share/', self.no_content)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class ReactionViewTest(TestCase):

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -8,7 +8,8 @@ from .views import (
     TagList,
     CommentListCreateAPIView,
     CommentRetrieveUpdateDestroyAPIView,
-    ThreadListCreateAPIView
+    ThreadListCreateAPIView,
+    ShareArticle
 )
 
 urlpatterns = [
@@ -24,4 +25,5 @@ urlpatterns = [
     path('articles/<str:slug>/comments/<int:id>/thread/',
          ThreadListCreateAPIView.as_view()
          ),
+    path('article/share/', ShareArticle.as_view()),
 ]


### PR DESCRIPTION
#### What does PR do?
Allows a logged in user to share an article
#### Description of tasks to be completed?
Currently, a user can not share an article.
This PR adds functionality to allow a logged user share an article using email.
#### How should this be manually tested?
Run the server python manage.py runserver

#### Create a body to share
Open postman and copy this URL POST ``` http://127.0.0.1:8000/api/article/share/ ```
Add the body in the format shown below:
``` 
{
    "article": {
    	"share_with": "<receipient_email>",
        "content": "<article_slug>"
        }
}
 ```
An article should be shared and successful message returned.

#### What are the relevant pivotal tracker stories?
[#160609568](https://www.pivotaltracker.com/story/show/160609568)

#### Screenshots
Response from sharing an article
![image](https://user-images.githubusercontent.com/7983999/47087212-15ba8100-d224-11e8-84f1-41277ac46183.png)

