### PR TITLE
#161284222 Fix unauthenticated users unable to view articles list

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -2,7 +2,8 @@ from authors.apps.authentication.backends import JWTAuthentication
 from rest_framework import generics, status
 from rest_framework.permissions import (
     IsAuthenticatedOrReadOnly,
-    IsAuthenticated
+    IsAuthenticated,
+    AllowAny
 )
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -106,6 +107,7 @@ class ArticleList(generics.ListAPIView):
 
     renderer_classes = (ArticleJSONRenderer,)
     serializer_class = ArticleSerializer
+    permission_classes = (AllowAny,)
 
     def get_queryset(self):
         queryset = Article.objects.all()


### PR DESCRIPTION
### What does this PR do?

Change permission class on view for articles list to `AllowAny`

#### Description of Task to be completed?

Apparently, unauthenticated users are not able to view the articles list because the permission class for ArticlesListView is set to `IsAuthenticated` by default.

This PR fixes this bug by adding a permission class of `AllowAny` on the ArticlesListView.


#### How should this be manually tested?

Make migrations: `python manage.py makemigrations`
Migrate: `python manage.py migrate` 
Run the server: `python manage.py runserver`

Open postman, create a user and POST an article as this user using `http://127.0.0.1:8000/api/articles/`

{
  "article": {
    	"title": "Get articles list",
    	"description": "Testing",
    	"body": "Whether am authenticated or not",
    	"tagList": ["authentication"]
    	}
}

With authorization disabled on postman, GET articles list using `http://127.0.0.1:8000/api/article/`

#### What are the relevant pivotal tracker stories?

- [#161284222](https://www.pivotaltracker.com/story/show/161284222)

#### Screenshots (if appropriate)

Currently
<img width="1044" alt="previously" src="https://user-images.githubusercontent.com/31615608/47139202-e4918d80-d2c3-11e8-8155-48ccc76a8a98.png">

After bug fix
<img width="1112" alt="and now" src="https://user-images.githubusercontent.com/31615608/47139231-f3784000-d2c3-11e8-84a6-9fbadd435472.png">
