### PR TITLE
#160609569 add bookmarks to articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -112,7 +112,6 @@ class Tag(models.Model):
 
     def __str__(self):
         return self.tag
-   
 
 
 class Impression(models.Model):
@@ -194,3 +193,31 @@ class Comment(TimeStampedModel):
         parent_comment = Comment.objects.get(id=comment.parent)
         # import pdb; pdb.set_trace()
         return parent_comment.thread_count
+class Bookmark(models.Model):
+
+    slug = models.SlugField(max_length=140, null=True)
+    user = models.ForeignKey(User, models.SET_NULL, null=True)
+    article = models.ForeignKey(Article, models.SET_NULL, null=True)
+
+    def remove_bookmark(self, slug, user):
+        self.slug = slug
+        self.user = user
+
+        Article.get_article(slug=self.slug)
+        try:
+            Bookmark.objects.filter(slug=self.slug)
+
+            try:
+                Bookmark.objects.get(slug=self.slug, user=self.user)
+            except Bookmark.DoesNotExist:
+                error = {"error": "You have not bookmarked this article"}
+                raise exceptions.NotFound(error)
+
+        except Bookmark.DoesNotExist:
+            message = {"error": "No book mark found"}
+            raise exceptions.NotFound(message)
+        
+        bookmarked = Bookmark.objects.filter(
+            slug=self.slug, user=self.user
+        )
+        return bookmarked.delete()

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -5,7 +5,8 @@ from .models import (
     Impression,
     Reaction,
     Tag,
-    Comment
+    Comment,
+    Bookmark
 )
 from .relations import TagRelatedField
 
@@ -40,7 +41,6 @@ class TagSerializer(serializers.ModelSerializer):
 
     def to_representation(self, value):
         return value.tag
-        return Article.objects.create(author=author, **validated_data)
 
 
 class ReactionSerializer(serializers.ModelSerializer):
@@ -150,7 +150,20 @@ class CommentSerializer(serializers.ModelSerializer):
         )
 
 
-
 class ShareArticleSerializer(serializers.Serializer):
     content = serializers.CharField()
     share_with = serializers.CharField()
+class BookmarkSerializer(serializers.ModelSerializer):
+    bookmarked_article = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Bookmark
+        fields = ['slug', 'user', 'bookmarked_article']
+    
+    def create(self, validated_data):
+        article = self.context.get('article', None)
+        user = self.context.get('user', None)
+        return Bookmark.objects.create(article=article, user=user, **validated_data)
+    
+    def get_bookmarked_article(self, object):
+        return ArticleSerializer(object.article).data

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -9,7 +9,8 @@ from .views import (
     CommentListCreateAPIView,
     CommentRetrieveUpdateDestroyAPIView,
     ThreadListCreateAPIView,
-    ShareArticle
+    ShareArticle,
+    BookmarkAPIView
 )
 
 urlpatterns = [
@@ -26,4 +27,5 @@ urlpatterns = [
          ThreadListCreateAPIView.as_view()
          ),
     path('article/share/', ShareArticle.as_view()),
+    path('articles/<str:slug>/bookmark/', BookmarkAPIView.as_view())
 ]


### PR DESCRIPTION
#### What does this PR do?

-Authenticated users can bookmark an article
-Authenticated users can view all their bookmarked articles
-Authenticated users when viewing a specific article can see if it is bookmarked or not.
-Authenticated users can remove bookmarks from articles
#### Description of Task to be completed?

Currently, authenticated users cannot bookmark articles.

This task allows authenticated users to bookmark articles for reading later, remove a bookmark from an article, view all bookmarked articles and view whether an article is bookmarked or not.


#### How should this be manually tested?

Make migrations:  `./manage.py makemigrations articles`
Migrate: `./manage.py migrate`
Run the server: `./manage.py runserver`
Open postman and test these endpoints: **Note**; All endpoints are authenticated

**Bookmark an article** 
POST `http://127.0.0.1:8000/api/articles/<slug>/bookmark/`

**Remove a bookmark from an article**
DELETE `http://127.0.0.1:8000/api/articles/<slug>/bookmark/`

**Get all bookmarked articles**
GET `http://127.0.0.1:8000/api/articles/?bookmark=true`

**Check if an article is bookmarked or not**
GET `http://127.0.0.1:8000/api/articles/<slug>/`

#### What are the relevant pivotal tracker stories?

[#160609569](https://www.pivotaltracker.com/story/show/160609569)



#### Any background context you want to add?
N/A


#### Screenshots
<img width="819" alt="screen shot 2018-10-18 at 09 59 37" src="https://user-images.githubusercontent.com/9901011/47139843-78b02480-d2c5-11e8-8d8b-a328a3b4d8e5.png">


<img width="1005" alt="screen shot 2018-10-18 at 10 39 46" src="https://user-images.githubusercontent.com/9901011/47138867-31289900-d2c3-11e8-9ff1-9abc4d2b3afd.png">


