### PR TITLE
#160609559 enable user following

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -20,7 +20,7 @@ from .models import (
     Comment
 )
 from authors.apps.authentication.backends import JWTAuthentication
-from authors.apps.profiles.serializers import ProfileSerializer
+from authors.apps.profiles.serializers import ProfileListSerializer
 from authors.apps.articles.exceptions import NotFoundException
 
 from .renderers import (
@@ -76,7 +76,7 @@ class ArticleRetrieveUpdate(APIView):
         serializer = self.serializer_class(article)
 
         profile = Article.get_profile(serializer.data['author'])
-        profile_serializer = ProfileSerializer(profile)
+        profile_serializer = ProfileListSerializer(profile)
 
         return Response(
                 {"article": {

--- a/authors/apps/profiles/exceptions.py
+++ b/authors/apps/profiles/exceptions.py
@@ -1,0 +1,14 @@
+"""
+Class to handle exceptions
+"""
+
+from rest_framework.exceptions import APIException
+
+
+class NotFoundException(APIException):
+    """
+    Provides 404 not found error
+    """
+    default_code = "not_found"
+    default_detail = "The requested resource was not found."
+    status_code = 404

--- a/authors/apps/profiles/models.py
+++ b/authors/apps/profiles/models.py
@@ -8,6 +8,18 @@ class Profile(TimeStampedModel):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     bio = models.TextField(blank=True)
     avatar = models.URLField(blank=True)
+    following = models.ManyToManyField(
+        'self', related_name='followers', symmetrical=False
+    )
 
     def __str__(self):
         self.user.username
+    
+    def follow(self, profile):
+        self.following.add(profile)
+    
+    def unfollow(self, profile):
+        self.following.remove(profile)
+    
+    def is_following(self, profile):
+        return self.following.filter(pk=profile.pk).exists()

--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -7,13 +7,47 @@ class ProfileSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')
     bio = serializers.CharField(allow_blank=True, required=False)
     avatar = serializers.SerializerMethodField()
+    following = serializers.SerializerMethodField()
+    followers = serializers.SerializerMethodField()
 
     class Meta:
         model = Profile
-        fields = ('username', 'bio', 'avatar',)
+        fields = ('username', 'bio', 'avatar', 'following', 'followers')
         read_only_fields = ('username',)
+    
+    def get_avatar(self, obj):
+        if obj.avatar:
+            return obj.avatar
+        return "https://pixabay.com/en/user-person-people-profile-account-1633249/"
+    
+    def helper(self, field):
+        request = self.context.get('request', None)
 
-    def get_avatar(seld, obj):
+        if field == 'following':
+            profiles = request.user.profile.following.all()
+        elif field == 'followers':
+            profiles = request.user.profile.followers.all()
+
+        return [profile.user.username for profile in profiles]
+    
+    def get_following(self, instance):
+        return self.helper('following')
+    
+    def get_followers(self, instance):
+        return self.helper('followers')
+
+
+class ProfileListSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(source='user.username')
+    bio = serializers.CharField(allow_blank=True, required=False)
+    avatar = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Profile
+        fields = ('username', 'bio', 'avatar')
+        read_only_fields = ('username',)
+    
+    def get_avatar(self, obj):
         if obj.avatar:
             return obj.avatar
         return "https://pixabay.com/en/user-person-people-profile-account-1633249/"

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -2,11 +2,14 @@ from django.urls import path
 
 from .views import (
     ProfileRetrieveUpdateAPIView,
-    ProfileList
+    ProfileList,
+    FollowAPIView
 )
 
 urlpatterns = [
     path('profiles/<username>/', ProfileRetrieveUpdateAPIView.as_view()),
     path('profiles/update/', ProfileRetrieveUpdateAPIView.as_view()),
     path('profile/', ProfileList.as_view()),
+    path('profiles/<username>/follow/', FollowAPIView.as_view()),
+    path('profiles/<username>/unfollow/', FollowAPIView.as_view()),
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -1,16 +1,27 @@
 from django.shortcuts import render
-from rest_framework import status
+from rest_framework import (
+    status,
+    serializers
+)
 from rest_framework.generics import (
     RetrieveUpdateAPIView,
     RetrieveAPIView
 )
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import (
+    AllowAny,
+    IsAuthenticated
+)
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from authors.apps.authentication.backends import JWTAuthentication
 from .renderers import ProfileJSONRenderer
-from .serializers import ProfileSerializer
+from .serializers import (
+    ProfileSerializer,
+    ProfileListSerializer
+)
 from .models import Profile
+from .exceptions import NotFoundException
 
 
 class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
@@ -27,9 +38,11 @@ class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
         except Profile.DoesNotExist:
             raise TypeError('Profile does not exist')
 
-        serializer = self.serializer_class(profile)
+        serializer = self.serializer_class(profile, context={'request': profile})
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+        current_user = self.request.user
 
     def update(self, request, *args, **kwargs):
         user_data = request.data.get('profile', {})
@@ -41,7 +54,10 @@ class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
         }
 
         serializer = self.serializer_class(
-            request.user.profile, data=serializer_data, partial=True
+            request.user.profile,
+            data=serializer_data,
+            partial=True,
+            context={'request': request}
         )
         serializer.is_valid(raise_exception=True)
         serializer.update(request.user.profile, serializer_data)
@@ -53,11 +69,75 @@ class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
 class ProfileList(RetrieveAPIView):
     renderer_classes = (ProfileJSONRenderer,)
-    serializer_class = ProfileSerializer
+    serializer_class = ProfileListSerializer
     permission_classes = (IsAuthenticated,)
     authentication_classes = (JWTAuthentication,)
 
     def retrieve(self, request, *args, **kwargs):
         queryset = Profile.objects.all()
-        serializer = self.serializer_class(queryset, many=True)
+        serializer = self.serializer_class(
+            queryset,
+            many=True,
+            context={'request': request}
+        )
         return Response({"users": serializer.data}, status=status.HTTP_200_OK)
+
+
+class FollowAPIView(APIView):
+    renderer_classes = (ProfileJSONRenderer,)
+    serializer_class = ProfileSerializer
+    permission_classes = (IsAuthenticated,)
+    authentication_classes = (JWTAuthentication,)
+
+    def post(self, request, username=None):
+        current_user = self.request.user
+
+        try:
+            follow = Profile.objects.get(user__username=username)
+        except Profile.DoesNotExist:
+            raise NotFoundException("The user requested for does not exist")
+        
+        if follow.pk is current_user.pk:
+            raise serializers.ValidationError("You can not follow yourself")
+        
+        current_user_profile = Profile.objects.get(user_id=current_user)
+
+        if current_user_profile.is_following(follow):
+            return Response(
+                {"message": "You are already following this user"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        current_user_profile.follow(follow)
+        current_user_profile.save()
+
+        serializer = self.serializer_class(
+            current_user_profile, context={'request': request}
+        )
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    def delete(self, request, username=None):
+        current_user = self.request.user
+
+        try:
+            unfollow = Profile.objects.get(user__username=username)
+        except Profile.DoesNotExist:
+            raise NotFoundException("The user requested for does not exist")
+        
+        current_user_profile = Profile.objects.get(user_id=current_user)
+
+        if not current_user_profile.is_following(unfollow):
+            return Response(
+                {"message": "You cannot unfollow a user you do not follow"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        current_user_profile.unfollow(unfollow)
+        current_user_profile.save()
+
+        serializer = self.serializer_class(
+            current_user_profile, context={'request': request}
+        )
+
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
### What does this PR do?

It allows users to follow and unfollow other users

### Description of tasks to be completed?

Currently, a user cannot follow or be followed by other users
This PR adds functionality to allow logged in users to follow and unfollow other users

### How should this be manually tested?

Make migrations `python manage.py makemigrations` and `python manage.py migrate`
Run the server `python manage.py runserver`

Open postman and:

***Follow a user***
POST `http://127.0.0.1:8000/api/profiles/<username>/follow/`

***Unfollow user***
DELETE `http://127.0.0.1:8000/api/profiles/<username>/unfollow/`


### What are the relevant pivotal tracker stories?

[#160609559](https://www.pivotaltracker.com/story/show/160609559)

### Any background context you want to add?

Please have at least two users registered before testing this feature.

### Screenshots
*Result of following a user*
<img width="1100" alt="follow" src="https://user-images.githubusercontent.com/38077368/47154260-7d3b0400-d2ea-11e8-92a2-d613dcb04143.png">

*Result of unfollowing a user*
<img width="1088" alt="unfollow" src="https://user-images.githubusercontent.com/38077368/47154278-904dd400-d2ea-11e8-844d-124a8a68fbaf.png">
