### PR TITLE
#160609574 Add user reading stats to the profile

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -72,6 +72,22 @@ class Article(models.Model):
         return str(int(round(time_to_read))) + ' minutes'
 
     @staticmethod
+    def get_reading_time_as_integer(reading_time):
+        """ Extract reading time as integer """
+
+        int_reading_time = 0
+        if reading_time == 'Less than a minute':
+            int_reading_time = 1
+        elif reading_time == 'About 1 minute':
+            int_reading_time = 2
+        else:
+            integers_found = [int(reading_time)
+                    for reading_time in str.split(reading_time)
+                    if reading_time.isdigit()]
+            int_reading_time = integers_found[0]
+        return int_reading_time
+
+    @staticmethod
     def get_profile(profile_id):
         return Profile.objects.get(id=profile_id)
 

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -13,7 +13,9 @@ from .relations import TagRelatedField
 class ArticleSerializer(serializers.ModelSerializer):
     """Create a new article"""
 
-    tagList = TagRelatedField(many=True, required=False, queryset=Tag.objects.all(), source='tags')
+    tagList = TagRelatedField(
+            many=True, required=False, 
+            queryset=Tag.objects.all(), source='tags')
 
     class Meta:
         model = Article
@@ -40,7 +42,6 @@ class TagSerializer(serializers.ModelSerializer):
 
     def to_representation(self, value):
         return value.tag
-        return Article.objects.create(author=author, **validated_data)
 
 
 class ReactionSerializer(serializers.ModelSerializer):

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -19,6 +19,10 @@ from rest_framework.permissions import (
     AllowAny
 )
 from pyisemail import is_email
+from authors.apps.authentication.models import User
+from authors.apps.profiles.models import Profile
+from authors.apps.authentication.serializers import UserSerializer
+
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -29,6 +33,7 @@ from .models import (
     Tag,
     Comment
 )
+from authors.apps.profiles.models import Profile
 from authors.apps.authentication.backends import JWTAuthentication
 from authors.apps.profiles.serializers import ProfileListSerializer
 from authors.apps.articles.exceptions import NotFoundException
@@ -61,14 +66,15 @@ class CreateArticle(generics.CreateAPIView):
         serializer_data = request.data.get('article', {})
 
         time_to_read = Article.article_reading_time(serializer_data['body'])
-        serializer_data['readingTime'] = time_to_read
+        serializer_data['reading_time'] = time_to_read
         serializer = self.serializer_class(data=serializer_data,
                                            context=serializer_context)
 
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        return Response({"article": serializer.data}, status=status.HTTP_201_CREATED)
+        return Response({"article": serializer.data},
+                        status=status.HTTP_201_CREATED)
 
 
 class ArticleRetrieveUpdate(APIView):
@@ -88,6 +94,21 @@ class ArticleRetrieveUpdate(APIView):
 
         profile = Article.get_profile(serializer.data['author'])
         profile_serializer = ProfileListSerializer(profile)
+        # profile_serializer = ProfileSerializer(profile)
+        reader_profile = Profile.objects.get(user=request.user)
+
+        # The user's reading stats are only incremented if
+        # he/she reads an article
+        # that is not theirs
+        if reader_profile and reader_profile != profile:
+            reading_time = serializer.data['reading_time']
+            current_stats = reader_profile.reading_stats
+            increment = Article.get_reading_time_as_integer(
+                reading_time)
+            new_stats = Profile.increment_read_stats(
+                current_stats, increment)
+            Profile.objects.filter(user=request.user).update(
+                reading_stats=new_stats)
 
         return Response(
                 {"article": {
@@ -116,7 +137,8 @@ class ArticleRetrieveUpdate(APIView):
         :return article"""
 
         article = Article.get_user_article(user_email=request.user, slug=slug)
-        serializer = self.serializer_class(article, data=request.data['article'])
+        serializer = self.serializer_class(
+            article, data=request.data['article'])
         serializer.is_valid(raise_exception=True)
         serializer.save()
 

--- a/authors/apps/profiles/models.py
+++ b/authors/apps/profiles/models.py
@@ -23,3 +23,25 @@ class Profile(TimeStampedModel):
     
     def is_following(self, profile):
         return self.following.filter(pk=profile.pk).exists()
+    reading_stats = models.CharField(max_length=100, default='0 minutes')
+
+    def __str__(self):
+        self.user.username
+
+    @staticmethod
+    def increment_read_stats(current_reading_stats, int_reading_time):
+        """ 
+        Increment the user's reading stats 
+        by the reading time of the article they have fetched
+        """
+
+        integers_found = [int(current_reading_stats)
+                    for current_reading_stats in
+                    str.split(current_reading_stats)
+                    if current_reading_stats.isdigit()]
+        cur_reading_stats = integers_found[0]
+        read_stats = cur_reading_stats + int_reading_time
+        if read_stats == 1:
+            return '1 minute'
+        else:
+            return str(int(read_stats)) + ' minutes'

--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -7,12 +7,11 @@ class ProfileSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')
     bio = serializers.CharField(allow_blank=True, required=False)
     avatar = serializers.SerializerMethodField()
-    following = serializers.SerializerMethodField()
-    followers = serializers.SerializerMethodField()
+    reading_stats = serializers.CharField(max_length=100)
 
     class Meta:
         model = Profile
-        fields = ('username', 'bio', 'avatar', 'following', 'followers')
+        fields = ('username', 'bio', 'avatar', 'reading_stats', 'reading_stats')
         read_only_fields = ('username',)
     
     def get_avatar(self, obj):

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -50,7 +50,9 @@ class ProfileRetrieveUpdateAPIView(RetrieveUpdateAPIView):
         serializer_data = {
             'username': user_data.get('username', request.user.username),
             'bio': user_data.get('bio', request.user.profile.bio),
-            'avatar': user_data.get('avatar', request.user.profile.avatar)
+            'avatar': user_data.get('avatar', request.user.profile.avatar),
+            'reading_stats': user_data.get('reading_stats', 
+                            request.user.profile.reading_stats)
         }
 
         serializer = self.serializer_class(


### PR DESCRIPTION
### What does this PR do?

Generates reading stats of a user and displays the stats on the user’s profile. 
The reading stats are obtained from the number of articles are logged-in user has read

#### Description of Task to be completed?

Currently, a user of can not see their reading stats 

This PR adds functionality to generate the reading stats of a user from the articles they have read and displays it in their profile. A user reading their own article does not any reading time

#### How should this be manually tested?

Make migrations: `python manage.py makemigrations`
Migrate: `python manage.py migrate` 
Run the server: `python manage.py runserver`
Open postman, create a user and POST an article as this user using `http://127.0.0.1:8000/api/articles/`

{
  "article": {
    	"title": "Reading stats",
    	"description": "Testing",
    	"body": "I am testing to confirm I am testing to confirm I am testing to confirm I am testing to confirm I am testing to confirm"	}
}

Create a second user and GET the previously created article using `http://127.0.0.1:8000/api/articles/<str:slug>/`
View the profile of the second user using `http://127.0.0.1:8000/api/profiles/<username>` to see their reading stats


#### What are the relevant pivotal tracker stories?

- [#160609574](https://www.pivotaltracker.com/story/show/160609574)

#### Screenshots (if appropriate)
<img width="1044" alt="reading stats" src="https://user-images.githubusercontent.com/31615608/47174838-6f04dc00-d31a-11e8-9ecb-071b464a6d2f.png">

