### PR TITLE
#161717042 view articles authored by the user

### DIFF
--- a/authors/apps/articles/tests.py
+++ b/authors/apps/articles/tests.py
@@ -146,6 +146,10 @@ class ViewTest(TestCase):
         response = self.method_to_call_on_route('/api/article/share/', self.no_content)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_can_return_articles_for_user(self):
+        result = self.client.get('/api/article/my-articles/')
+        self.assertEqual(result.status_code, status.HTTP_200_OK)
+
 
 class ReactionViewTest(TestCase):
 

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -9,7 +9,8 @@ from .views import (
     CommentListCreateAPIView,
     CommentRetrieveUpdateDestroyAPIView,
     ThreadListCreateAPIView,
-    ShareArticle
+    ShareArticle,
+    ReturnArticle
 )
 
 urlpatterns = [
@@ -26,4 +27,6 @@ urlpatterns = [
          ThreadListCreateAPIView.as_view()
          ),
     path('article/share/', ShareArticle.as_view()),
+    path('article/my-articles/', ReturnArticle.as_view()),
+    
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -48,6 +48,17 @@ from .serializers import (
 )
 
 
+class ReturnArticle(APIView):
+    renderer_classes = (ArticleJSONRenderer,)
+    serializer_class = ArticleSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request):
+        articles = Article.objects.filter(author_id=request.user.id)
+        serializer = self.serializer_class(articles, many=True)
+        return Response({'article': serializer.data}, status=status.HTTP_200_OK)    
+
+
 class CreateArticle(generics.CreateAPIView):
     """Class for creation of an article"""
 


### PR DESCRIPTION
#### What does this PR do?

Allow authenticated users that are authors view their articles
#### Description of Task to be completed?

Currently, our application only returns all articles

This task allows us to return articles for an authenticated user


#### How should this be manually tested?

Run the server `./manage.py runserver`
On postman create articles using different users
Using their respective tokens navigate to `http://127.0.0.1:8000/api/article/my-articles/`

#### What are the relevant pivotal tracker stories?

[#161717042](https://www.pivotaltracker.com/story/show/161717042)



#### Any background context you want to add?
N/A



#### Screenshots
![image](https://user-images.githubusercontent.com/9901011/48020231-7c0d3200-e146-11e8-9f9b-e1f3808419e8.png)
