### PR TITLE
#161722957 Change email link sent to include URL.

### DIFF
--- a/authors/apps/authentication/tests.py
+++ b/authors/apps/authentication/tests.py
@@ -261,7 +261,7 @@ class ViewTestCase(TestCase):
     def test_send_email_on_registration(self):
         token = generate_ver_token(self.user_data['user']['email'], 60)
         res = send_verification_link(self.user_data['user']['email'], token)
-        self.assertEqual(res.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(res, 1)
 
 
 class ValidatorsTestCase(TestCase):

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -138,6 +138,13 @@ CORS_ORIGIN_WHITELIST = (
     'ah-frontend-targaryen-staging.herokuapp.com',
 )
 
+# Email Settings
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = config('EMAIL_HOST')
+EMAIL_USE_TLS = True
+EMAIL_PORT = 587
+EMAIL_HOST_USER = config('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
 
 # Tell Django about the custom `User` model we created. The string
 # `authentication.User` tells Django we are referring to the `User` model in

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,8 @@ django-rest-swagger==2.2.0
 djangorestframework==3.8.2
 dnspython==1.15.0
 docopt==0.6.2
-facebook-sdk==3.0.0
 future==0.16.0
+facebook-sdk==3.0.0
 futures==3.1.1
 google-auth==1.5.1
 gunicorn==19.9.0
@@ -54,6 +54,8 @@ rsa==4.0
 sendgrid==5.6.0
 simplejson==3.16.0
 six==1.10.0
+social-auth-app-django==2.1.0
+social-auth-core==1.7.0
 uritemplate==3.0.0
 urllib3==1.23
 whitenoise==4.1


### PR DESCRIPTION
#### What does this PR do?
Updates the link sent to email to include a URL.

#### Description of Task to be completed?
Currently, the link sent to a user's email is a token.
This PR includes a URL that the user can click on to be redirected to a reset-password page.

#### How should this be manually tested?
 - set `EMAIL_HOST` `EMAIL_PORT`, `EMAIL_USE_TLS`, `EMAIL_HOST_USER` `EMAIL_HOST_PASSWORD` and `LOCAL_URL` in the local environment file or using export in the terminal.

 - http://localhost:3000/reset-password/ is the `LOCAL_URL` to use if the frontend that handles email reset is being run locally.

 - Register a user by using a POST method on the endpoint of /api/users, entering the user data in format below
{
"user":{
"username": “Username”,
"email": “your@email.com”,
"password": “password1”
}
}
 - POST, at the 'users/password_reset/' endpoint, the follwoing user details;
{
  "user":{
    "username": "Username",
    "email": "your@email.com"
  }
}
- Check the email used above for the link to the reset password page.

#### What are the relevant pivotal tracker stories?
[#161722957](https://www.pivotaltracker.com/story/show/161722957)
