### PR TITLE
#161913720 Display article reading time and arrange articles in descending order

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -54,7 +54,7 @@ class ReturnArticle(APIView):
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):
-        articles = Article.objects.filter(author_id=request.user.id)
+        articles = Article.objects.filter(author_id=request.user.id).order_by('-createdAt')
         serializer = self.serializer_class(articles, many=True)
         return Response({'article': serializer.data}, status=status.HTTP_200_OK)    
 
@@ -72,7 +72,7 @@ class CreateArticle(generics.CreateAPIView):
         serializer_data = request.data.get('article', {})
 
         time_to_read = Article.article_reading_time(serializer_data['body'])
-        serializer_data['readingTime'] = time_to_read
+        serializer_data['reading_time'] = time_to_read
         serializer = self.serializer_class(data=serializer_data,
                                            context=serializer_context)
 
@@ -156,7 +156,7 @@ class ArticleList(generics.ListAPIView):
     permission_classes = (AllowAny,)
 
     def get_queryset(self):
-        queryset = Article.objects.all()
+        queryset = Article.objects.all().order_by('-createdAt')
         return queryset
 
 


### PR DESCRIPTION
#### What does this PR do?

Allow all users to view articles with reading time and from the newest articles to the oldest

#### Description of Task to be completed?

Currently, the articles returned display `null` for reading time and are in ascending order(oldest to latest)

This task allows users view article reading time and the articles are displayed in descending order


#### How should this be manually tested?

- Run the application, `./manage.py runserver`
- Navigate to the endpoint to view all articles *GET* `http://localhost:8000/api/article/`

#### What are the relevant pivotal tracker stories?

[#161913720](https://www.pivotaltracker.com/story/show/161913720)



#### Any background context you want to add?
N/A



#### Screenshots
![image](https://user-images.githubusercontent.com/9901011/48403415-ddcd2d80-e73e-11e8-8081-36ca87cb59ef.png)

