### PR TITLE
#162043632 Change reset link to button and fix bug in the like/dislike feature.

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -255,23 +255,27 @@ class ReactionView(APIView):
 
         try:
             article = Article.get_article(slug=slug)
-            reaction= Impression.objects.get(
+            reaction_impression = Impression.objects.get(
                 name=request.data['reaction']
             )
             reaction = Reaction.objects.get(
                 article=article.id,
                 user=request.user.id,
-                reaction=reaction
+                reaction=reaction_impression.id
             )
             message = self.check_reaction(
                 request.data['reaction'],
                 request
             )
             ReactionSerializer.reaction_value(
-                reaction.id, article.slug, article, -1
+                reaction_impression.id, article.slug, article, -1
             )
             reaction.delete()
             return Response(message, status=status.HTTP_204_NO_CONTENT)
+
+        except Reaction.DoesNotExist:
+            message = 'You have not yet interacted with this article'
+            raise exceptions.ParseError(message)
 
         except Reaction.DoesNotExist:
             message = 'You have not yet interacted with this article'

--- a/authors/apps/authentication/templates/reset_password_email.html
+++ b/authors/apps/authentication/templates/reset_password_email.html
@@ -1,0 +1,66 @@
+
+<table 
+    style=" background-color: #171f23de; max-width:670px; margin:0 auto;"
+    width="100%" 
+    border="0"
+    align="center"
+    cellpadding="0"
+    cellspacing="0"
+>
+    <tbody>
+        <tr>
+            <td style="height:20px;">&nbsp;</td>
+        </tr>
+        <tr>
+            <td>
+                <table
+                    width="95%"
+                    border="0"
+                    align="center"
+                    style="
+                        max-width:670px;
+                        background:#fff;
+                        border-radius:3px;
+                        text-align:center;"
+                >
+                    <tbody>
+                        <tr>
+                            <td style="height:40px;">&nbsp;</td>
+                        </tr>
+                        <tr>
+                            <td style="padding:0 15px;">
+                                <h1 style="color:#171f23de; font-weight:400; margin:0;font-size:30px;">
+                                    Click this button to reset your authors haven password
+                                </h1>
+                                <a href="{{url}}"
+                                style="
+                                    background:#000000c9;text-decoration:none !important;
+                                    font-weight:500;
+                                    margin-top:35px;
+                                    margin-bottom:35px;
+                                    color:#fff;
+                                    text-transform:uppercase;
+                                    font-size:14px;
+                                    padding:10px 12px;
+                                    display:inline-block;border-radius:3px;"
+                                >Reset Password</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td style="height:20px;">&nbsp;</td>
+        </tr>
+    </tbody>
+</table>
+<table align="center">
+    <tbody>
+        <tr>
+            <td>
+                <p align="center">If you  did not request for the password change, please ignore this email.</p>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -52,9 +52,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
#### What does this PR do?
This PR Changes the link sent in an email to a button. It also fixes a bug that prevented users from interacting with the like dislike feature more than once.

#### Description of Task to be completed?
Currently, users are presented with a link that is plain text. This task makes the link a button user can click on.



#### How should this be manually tested?

- Run the application, `./manage.py runserver`
- Register a user by using a POST method on the endpoint of /api/users, entering the user data in format below
{
"user":{
"username": “Username”,
"email": “your@email.com”,
"password": “password1”
}
}
 - POST, at the 'users/password_reset/' endpoint, the follwoing user details;
{
  "user":{
    "username": "Username",
    "email": "your@email.com"
  }
}
- Check the email used in the above post to view the button.

#### What are the relevant pivotal tracker stories?
[#162043632](https://www.pivotaltracker.com/story/show/162043632)

