### PR TITLE
#162127045 add author name to comment

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -150,6 +150,7 @@ class Comment(TimeStampedModel):
         on_delete=models.CASCADE,
         null=True
     )
+    author_name = models.TextField(null=True)
     article = models.ForeignKey(
         'articles.Article',
         on_delete=models.CASCADE,

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -136,17 +136,50 @@ class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         fields = [
-            'id', 'author', 'article', 'body',
+            'id', 'author', 'author_name', 'article', 'body',
             'parent', 'created_at', 'updated_at', 'thread_count'
         ]
 
     def create(self, validated_data):
+        author_name = self.context.get('author_name', None)
+        author = self.context.get('author', None)
+        article = self.context.get('article', None)
+        parent = self.context.get('parent', None)
+
+        return Comment.objects.create(
+            author_name=author_name,
+            author=author,
+            article=article,
+            parent=parent,
+            **validated_data
+        )
+
+
+class CommentCreateSerializer(serializers.ModelSerializer):
+    author_name = serializers.SerializerMethodField()
+
+    def get_author_name(self, field):
+        request = self.context.get('author', None)
+
+        profile = request.user.profile
+        return profile.user.username
+
+    class Meta:
+        model = Comment
+        fields = [
+            'id', 'author', 'author_name', 'article', 'body',
+            'parent', 'created_at', 'updated_at', 'thread_count'
+        ]
+
+    def create(self, validated_data):
+        author_name = self.get_author_name('author')
         author = self.context.get('author', None)
         article = self.context.get('article', None)
         parent = self.context.get('parent', None)
 
         return Comment.objects.create(
             author=author,
+            author_name=author_name,
             article=article,
             parent=parent,
             **validated_data

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -45,6 +45,7 @@ from .serializers import (
     ArticleSerializer,
     ReactionSerializer,
     TagSerializer,
+    CommentCreateSerializer,
     CommentSerializer,
     ShareArticleSerializer,
     RateSerializer
@@ -285,6 +286,7 @@ class ReactionView(APIView):
 class CommentListCreateAPIView(generics.ListCreateAPIView):
     renderer_classes = (CommentJSONRenderer,)
     serializer_class = CommentSerializer
+    serializer_create_class = CommentCreateSerializer
     permission_classes = (IsAuthenticated,)
     authentication_classes = (JWTAuthentication,)
     queryset = Comment.objects.all()
@@ -297,7 +299,7 @@ class CommentListCreateAPIView(generics.ListCreateAPIView):
             }
             serializer_data = request.data.get('comment', {})
 
-            serializer = self.serializer_class(
+            serializer = self.serializer_create_class(
                 data=serializer_data,
                 context=serializer_context
             )


### PR DESCRIPTION
#### What does this PR do?
This PR adds a field of author's username to a comment's payload

#### Description of Task to be completed?
Currently, the username of an author of a comment is not included in the comment's payload.
This PR adds the username field to the comment's payload



#### How should this be manually tested?

- Run the application, `./manage.py runserver`
- Post a comment in postman: 
POST `.../api/articles/user-1-today/comments/`
Body
```
{
	"comment": {
		"body": "three comments here"
	}
}
```
You should see a payload with the username of the author as part of the returned fields